### PR TITLE
build: update tsconfig.json to support monorepo path mappings

### DIFF
--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -7,8 +7,9 @@ import { AppWrapper } from 'dhis2-semis-components'
 import { D2I18n } from 'dhis2-semis-types'
 // import translation from '../locales/index'
 
-const Enrollment = ({ i18n }: { i18n: D2I18n }) => {
-    const { baseUrl } = useConfig()
+const Enrollment = ({ i18n, baseUrl }: { i18n: D2I18n, baseUrl: string }) => {
+    const { baseUrl: localBaseUrl } = useConfig()
+    const useBaseUrl = baseUrl || localBaseUrl
     // const translate = i18n ? i18n : translation
 
     return (
@@ -18,7 +19,7 @@ const Enrollment = ({ i18n }: { i18n: D2I18n }) => {
         //     schoolCalendarKey='dataStore/semis/schoolCalendar'
         // >
         //     <HashRouter>
-                <Router i18n={i18n as unknown as any} />
+        <Router i18n={i18n as unknown as any} baseUrl={useBaseUrl} />
         //     </HashRouter >
         // </AppWrapper>
     )

--- a/src/components/routes/Router.tsx
+++ b/src/components/routes/Router.tsx
@@ -4,11 +4,11 @@ import { Routes, Route } from 'react-router-dom';
 import WithHeaderBarLayout from '../../layout/WithHeaderBarLayout';
 import { D2I18n } from 'dhis2-semis-types';
 
-export default function Router({ i18n }: { i18n: D2I18n }) {
+export default function Router({ i18n, baseUrl }: { i18n: D2I18n, baseUrl: string }) {
     return (
         <Routes>
             <Route path='/'
-                element={<WithHeaderBarLayout />}
+                element={<WithHeaderBarLayout baseUrl={baseUrl} />}
             >
                 <Route key={'enrollments'} path={'/'} element={<Enrollment i18n={i18n} />} />
             </Route>

--- a/src/layout/WithHeaderBarLayout.tsx
+++ b/src/layout/WithHeaderBarLayout.tsx
@@ -1,10 +1,8 @@
 import { Outlet } from "react-router-dom"
-import { useConfig } from "@dhis2/app-runtime"
 import useGetSelectedKeys from "../hooks/config/useGetSelectedKeys"
 import { HeaderBarLayout, SemisHeader, useSchoolCalendarKey } from "dhis2-semis-components"
 
-const WithHeaderBarLayout = () => {
-    const { baseUrl } = useConfig()
+const WithHeaderBarLayout = ({ baseUrl }: { baseUrl: string }) => {
     const schoolCalendar = useSchoolCalendarKey()
     const { program, dataStoreData } = useGetSelectedKeys()
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -21,7 +21,12 @@
       "declarationDir": "./dist/declarations",
       "jsx": "preserve",
       "outDir": "./dist",
-      "rootDir": "./src",
+      "rootDir": "../..",
+      "paths": {
+        "dhis2-semis-components": ["../../libs/components/src"],
+        "dhis2-semis-functions": ["../../libs/functions/src"],
+        "dhis2-semis-types": ["../../libs/types/src"]
+      }
   },
   "exclude": [
       "node_modules",


### PR DESCRIPTION
Add path aliases for internal packages to enable proper module resolution within the monorepo structure. This allows TypeScript to correctly resolve imports from @dhis2/semis-components, @dhis2/semis-functions, and @dhis2/semis-types packages during development and compilation.