### PR TITLE
fix(Router): pass baseUrl prop to Enrollment component

### DIFF
--- a/src/components/routes/Router.tsx
+++ b/src/components/routes/Router.tsx
@@ -10,7 +10,7 @@ export default function Router({ i18n, baseUrl }: { i18n: D2I18n, baseUrl: strin
             <Route path='/'
                 element={<WithHeaderBarLayout baseUrl={baseUrl} />}
             >
-                <Route key={'enrollments'} path={'/'} element={<Enrollment i18n={i18n} />} />
+                <Route key={'enrollments'} path={'/'} element={<Enrollment i18n={i18n} baseUrl={baseUrl} />} />
             </Route>
         </Routes>
     );


### PR DESCRIPTION
The Enrollment component requires the baseUrl prop to function correctly, but it was missing in the route configuration. This ensures proper navigation and URL construction within the Enrollment feature.